### PR TITLE
Refactoring CANListener, adding name and number to CAN_COMMON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+NAME = libcan_common.a
+
+SOURCE_DIR = src
+SOURCES = $(wildcard $(SOURCE_DIR)/*.cpp)
+SOURCE_BASENAMES = $(notdir $(SOURCES))
+
+INCLUDE_DIR = $(SOURCE_DIR)
+INCLUDES = $(wildcard $(SOURCE_DIR)/*.h)
+# CXXFLAGS = -Wall -Werror -Wextra -I$(INCLUDE_DIR)
+CXXFLAGS = -I$(INCLUDE_DIR)
+
+# ------------------------------------------------------------------------------#
+# This method of directory creation is adapted from:
+# https://gist.github.com/maxtruxa/4b3929e118914ccef057f8a05c614b0f
+
+# intermediate directory for generated object files
+OBJECT_DIR := .o
+
+# object files, auto generated from source files
+OBJECTS := $(patsubst %,$(OBJECT_DIR)/%.o,$(basename $(SOURCE_BASENAMES)))
+# ------------------------------------------------------------------------------#
+
+
+.SUFFIXES: # remove the default suffix rules, because the GNU Make manual states:
+# Suffix rules are the old-fashioned way of defining implicit rules for make.
+# Suffix rules are obsolete because pattern rules are more general and clearer.
+# They are supported in GNU make for compatibility with old makefiles.
+all: $(NAME)
+
+$(NAME): $(OBJECTS)
+	ar -r $@ $^
+
+# https://stackoverflow.com/questions/38110010/pattern-rule-with-files-in-different-directories
+$(OBJECT_DIR)/%.o: $(SOURCE_DIR)/%.cpp $(INCLUDES)
+	$(shell mkdir -p $(dir $(OBJECTS)) >/dev/null)
+	$(CXX) -c $(CXXFLAGS) $< -o $@
+
+clean:
+	/bin/rm -rf $(OBJECT_DIR)
+
+fclean: clean
+	/bin/rm -f $(NAME)
+
+re: clean all
+	
+debug: CXXFLAGS += -g
+debug: fclean all	

--- a/src/can_common.h
+++ b/src/can_common.h
@@ -1,7 +1,13 @@
 #ifndef _CAN_COMMON_
 #define _CAN_COMMON_
 
+#ifdef __ARDUINO__
 #include <Arduino.h>
+#else
+#include <stdint.h>
+#include <string.h>
+typedef bool boolean;
+#endif // __ARDUINO__
 
 /** Define the typical baudrate for CAN communication. */
 #ifdef CAN_BPS_500K
@@ -165,6 +171,17 @@ public:
     uint8_t fdMode;       // 0 = normal CAN frame, 1 = CAN-FD frame
     uint8_t length;       // Number of data bytes
 };
+
+enum frame_direction_e {
+    FRAME_DIRECTION_RX = 0,
+    FRAME_DIRECTION_TX
+};
+
+typedef struct {
+    CAN_FRAME frame;
+    int bus_number;
+    frame_direction_e direction;
+} frameobject_t;
 
 class CANListener
 {


### PR DESCRIPTION
Hi Collin,
I made a couple API changes.  These are experimental -- they made sense in the project I'm working on.  I'm opening this PR not with merge-intent (it's a breaking change), but with the aim of seeing if they're consistent with your design intent.

1. `CAN_COMMON` defines `sendFrame`/`get_rx_buff`.  Children define private member functions `_sendFrame`/`_get_rx_buff` that actually do the sending/receiving.
    - aim: call `Listener::gotFrame` / `Listener::sentFrame` as hooks within `CAN_COMMON`, because their behavior should be consistent across children of `CAN_COMMON`
2. Rename `attachObj`/`detachObj` to `attachListener`/`detachListener`
    - aim: remove ambiguity on what's being attached/detached.
3. Add `name` and `bus_number` members to `CAN_COMMON`
    - aims: eliminate repeated definition of bus number, allow generic debug/log messages to name a specific bus.

Here's where I'm subclassing `CANListener`:
https://github.com/driftregion/SavvyCANServer/blob/master/SavvyCANListener.cpp