### PR TITLE
Make can_common.h unit test compatible

### DIFF
--- a/src/can_common.h
+++ b/src/can_common.h
@@ -1,7 +1,13 @@
 #ifndef _CAN_COMMON_
 #define _CAN_COMMON_
 
+#ifndef UNIT_TEST
 #include <Arduino.h>
+#else
+#include <stdint.h>
+#include <cstring>
+typedef bool boolean;
+#endif
 
 /** Define the typical baudrate for CAN communication. */
 #ifdef CAN_BPS_500K


### PR DESCRIPTION
I'm building a library to parse some messages around this.  I want to be able to run the unit tests natively on my workstation. Happy to hear if there is a better solution.