### PR TITLE
Return mailbox number from setRXFilter

### DIFF
--- a/src/can_common.cpp
+++ b/src/can_common.cpp
@@ -322,12 +322,12 @@ void CAN_COMMON::removeCallbackFD(uint8_t mailbox)
 
 int CAN_COMMON::setRXFilter(uint8_t mailbox, uint32_t id, uint32_t mask, bool extended)
 {
-    _setFilterSpecific(mailbox, id, mask, extended);
+	return _setFilterSpecific(mailbox, id, mask, extended);
 }
 
 int CAN_COMMON::setRXFilter(uint32_t id, uint32_t mask, bool extended)
 {
-    _setFilter(id, mask, extended);
+    return _setFilter(id, mask, extended);
 }
 
 int CAN_COMMON::watchFor() 


### PR DESCRIPTION
Required if you don't explicitly set the mailbox number - otherwise you've no idea which mailbox the filter was set into.  It's often easy to assume that they'll count up from 0 - but not in the case of the MCP2515 where the first two filters are only used by default if it's an extended filter.

Fixes #1